### PR TITLE
Add newline to output

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -32,5 +32,5 @@ func main()  {
 		log.Fatalf("Get available port failed with %v", err)
 	}
 
-	fmt.Printf("Found available port at: %v", openPort)
+	fmt.Printf("Found available port at: %v\n", openPort)
 }


### PR DESCRIPTION
Some shells, like zsh, explicitly show that newline is missing and add it to command output like that:

```sh
$ ./find-port-darwin-amd64
Found available port at: 61647%
$
```

Some other shells just start printing without the newline:

```sh
$ ./find-port-darwin-amd64
Found available port at: 61647$
```

Added newline to command output to fix that.