### PR TITLE
Add circleci configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,47 @@
+# Golang CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-go/ for more details
+version: 2
+jobs:
+  lint:
+    docker:
+      # https://hub.docker.com/r/circleci/golang/tags/
+      - image: circleci/golang:1.11
+    working_directory: ~/find-port
+    steps:
+      - checkout
+      - run: >
+          mkdir -p $GOPATH/bin;
+          export VER=1.10.2;
+          export NAME=golangci-lint-$VER-linux-amd64;
+          curl -sL https://github.com/golangci/golangci-lint/releases/download/v$VER/$NAME.tar.gz | tar -xzC $GOPATH/bin --transform s,$NAME/golangci-lint,golangci-lint, $NAME/golangci-lint
+      - run: golangci-lint run
+
+  deploy:
+    docker:
+      # https://hub.docker.com/r/circleci/golang/tags/
+      - image: circleci/golang:1.11
+    working_directory: ~/find-portg
+    steps:
+      - checkout
+      - run: go get -u github.com/mitchellh/gox github.com/tcnksm/ghr
+      - run: >
+          gox
+          -arch="amd64 arm" -os="darwin linux windows"
+          -parallel=2
+          -ldflags "-X findport.AppVersion=`git describe --tags`"
+          -output "dist/find-port-{{.OS}}-{{.Arch}}"
+          ./cmd
+      - run: ghr -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace `git describe --tags` dist/
+
+workflows:
+  version: 2
+  lint-and-deploy:
+    jobs:
+      - lint
+      - deploy:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 .glide/
 .idea/
 /vendor
+
+# Build result
+dist/

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	port int
+	AppVersion = "dev"
 	version bool
 )
 func init()  {
@@ -23,7 +23,7 @@ func init()  {
 func main()  {
 	flag.Parse()
 	if version {
-		fmt.Println(findport.AppVersion)
+		fmt.Println(AppVersion)
 		os.Exit(0)
 	}
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,0 @@
-package findport
-
-const AppVersion = "1.0.0"


### PR DESCRIPTION
Added configuration file to do the following:

Lint, build and deploy to github releases tab automatically when you add another vX.X.X tag.

Also version variable will be automatically populated with git tag name so you don't need to change it in code manually.

The only thing left for you is to go to circleci and register your github project in there.

Fixes #1